### PR TITLE
Timeout setting

### DIFF
--- a/datagarrison.js
+++ b/datagarrison.js
@@ -18,7 +18,6 @@ const fetchStream = ({ user, stream }, ms) => {
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), ms)
 
-  console.log('using local stream')
   return fetch(endpoint, {
     signal: controller.signal // assign controller's abort signal so the request times out after a specified time
   }).then(response => {


### PR DESCRIPTION
- Added an optional timeoutInMs setting to the `get` method to account for times when datagarrison endpoint takes more than 10 seconds to return results, resulting in a timeout.
   - set the timeout to 15 seconds by default if argument is not provided